### PR TITLE
Use constexpr more with VC++ 2017

### DIFF
--- a/src/google/protobuf/generated_message_table_driven.h
+++ b/src/google/protobuf/generated_message_table_driven.h
@@ -43,8 +43,8 @@
 
 // We require C++11 and Clang to use constexpr for variables, as GCC 4.8
 // requires constexpr to be consistent between declarations of variables
-// unnecessarily (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58541).
-#ifdef __clang__
+// VS 2017 Update 3 also supports this usage of constexpr.
+#if defined(__clang__) || (defined(_MSC_VER) && _MSC_VER >= 1911)
 #define PROTOBUF_CONSTEXPR_VAR constexpr
 #else  // !__clang__
 #define PROTOBUF_CONSTEXPR_VAR

--- a/src/google/protobuf/generated_message_table_driven.h
+++ b/src/google/protobuf/generated_message_table_driven.h
@@ -43,6 +43,7 @@
 
 // We require C++11 and Clang to use constexpr for variables, as GCC 4.8
 // requires constexpr to be consistent between declarations of variables
+// unnecessarily (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58541).
 // VS 2017 Update 3 also supports this usage of constexpr.
 #if defined(__clang__) || (defined(_MSC_VER) && _MSC_VER >= 1911)
 #define PROTOBUF_CONSTEXPR_VAR constexpr


### PR DESCRIPTION
Chrome's official builds have over 170 dynamic initializers for
variables of the form *::TableStruct::aux. Defining
PROTOBUF_CONSTEXPR_VAR to be constexpr for VS 2017 gets rid of all of
these and saves about 10 KB of binary size.

The Chromium bug crbug.com/341941 has more details.